### PR TITLE
Convert fmqttc_client to gen_statem

### DIFF
--- a/src/fmqttc_client.erl
+++ b/src/fmqttc_client.erl
@@ -1,6 +1,6 @@
 -module(fmqttc_client).
 
--behaviour(gen_server).
+-behaviour(gen_statem).
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -8,32 +8,32 @@
 
 -export([
     init/1,
-    terminate/2,
-    handle_call/3,
-    handle_cast/2,
-    handle_info/2
+    callback_mode/0,
+    terminate/3,
+    ready/3,
+    waiting_ack/3
 ]).
 
 start_link(Ctx) ->
-    gen_server:start_link(?MODULE, [Ctx], []).
+    gen_statem:start_link(?MODULE, [Ctx], []).
 
 init([#{name := Name} = Ctx]) ->
     process_flag(trap_exit, true),
     logger:set_process_metadata(#{domain => [fmqttc], module => ?MODULE, role => client}),
     ?LOG_INFO(#{name => Name, status => up}),
     _ = crypto:rand_seed(),
-    gen_server:cast(self(), start),
-    {ok, Ctx}.
+    gen_statem:cast(self(), connect),
+    {ok, ready, Ctx}.
 
-handle_call(_, _, Ctx) ->
-    {stop, unknown_call, Ctx}.
+callback_mode() ->
+    state_functions.
 
-handle_cast(start, #{name := Name} = Ctx) ->
+ready(cast, connect, #{name := Name} = Ctx) ->
     {ok, ConnPid} = emqtt:start_link([{clientid, Name}]),
     {ok, _Props} = emqtt:connect(ConnPid),
-    gen_server:cast(self(), publish),
-    {noreply, Ctx#{conn => ConnPid, packet_id => 0}};
-handle_cast(publish, Ctx) ->
+    gen_statem:cast(self(), publish),
+    {next_state, ready, Ctx#{conn => ConnPid, packet_id => 0}};
+ready(cast, publish, Ctx) ->
     #{
         topic := Topic,
         qos := QoS,
@@ -43,24 +43,24 @@ handle_cast(publish, Ctx) ->
     Msg = float_to_binary(Temp),
     ?LOG_INFO(#{op => publish, topic => Topic, temperature => Temp}),
     {ok, PktId} = emqtt:publish(ConnPid, Topic, Msg, QoS),
-    {noreply, Ctx#{packet_id := PktId}}.
-
-handle_info(timeout, #{temp := Temp0, trend := Trend} = Ctx) ->
+    {next_state, waiting_ack, Ctx#{packet_id := PktId}};
+ready(state_timeout, measure, #{temp := Temp0, trend := Trend} = Ctx) ->
     {ok, Temp} = Trend(Temp0),
-    gen_server:cast(self(), publish),
-    {noreply, Ctx#{temp := Temp}};
-handle_info({puback, PubAck}, #{interval := Timeout} = Ctx) ->
+    gen_statem:cast(self(), publish),
+    {next_state, ready, Ctx#{temp := Temp}}.
+
+waiting_ack(info, {puback, PubAck}, #{interval := Timeout} = Ctx) ->
     #{packet_id := PktId0} = PubAck,
     #{packet_id := PktId} = Ctx,
     case PktId0 =:= PktId of
         true ->
-            {noreply, Ctx, Timeout};
+            {next_state, ready, Ctx, [{state_timeout, Timeout, measure}]};
         false ->
             ?LOG_ERROR(#{reason => invalid_ack, ack => PubAck}),
             {stop, invalid_ack, Ctx}
     end.
 
-terminate(Reason, #{name := Name, conn := ConnPid}) ->
+terminate(Reason, _State, #{name := Name, conn := ConnPid}) ->
     ?LOG_INFO(#{name => Name, status => down, reason => Reason}),
     ok = emqtt:disconnect(ConnPid),
     ok.


### PR DESCRIPTION
Convert `fmqttc_client` to `gen_statem`, add more logging and a bit of refactoring.

Closes #6 